### PR TITLE
Avoid Error `adsbygoogle.push() error`

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -66,10 +66,23 @@ module.exports = function nuxtAdSense (moduleOptions = {}) {
 
   // Initialize Adsense with ad client id
   this.options.head.script.push({innerHTML: `
-      (adsbygoogle = window.adsbygoogle || []).push({
-        google_ad_client: "${options.id}",
-        enable_page_level_ads: ${options.pageLevelAds ? 'true' : 'false'}
-      });
+      var alreadyIncluded = false;
+
+      if(window.adsbygoogle) {
+        alreadyIncluded = window.adsbygoogle.reduce(
+          (acc, i) => {
+            var chk = i.enable_page_level_ads;
+            return chk || acc;
+          }
+        , false);
+      }
+
+      if(!alreadyIncluded) {
+        (adsbygoogle = window.adsbygoogle || []).push({
+          google_ad_client: "${options.id}",
+          enable_page_level_ads: ${options.pageLevelAds ? 'true' : 'false'}
+        });
+      }
   `})
 
   // If in DEV mode, add robots meta first to comply with Adsense policies


### PR DESCRIPTION
add check `windows.adsbygoogle` to avoid error like below;

```
H {message: "adsbygoogle.push() error: Only one 'enable_page_level_ads' allowed per page.", name: "TagError", stack: "TagError: adsbygoogle.push() error: Only one 'enab…s/adsbygoogle.js:1:69778)↵    at <anonymous>:2:48"}
```